### PR TITLE
Fix main module path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "fetch-sync",
   "version": "2.0.0",
   "description": "Proxy fetch requests through the Background Sync API",
-  "main": "lib/client/index.js",
-  "jsnext:main": "src/client/index.js",
+  "main": "lib/client.js",
+  "jsnext:main": "src/client.js",
   "author": "Sam Gluck <sdgluck@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The installed library does not have `lib/client/index.js`. The path is rather `lib/client.js`.

![image](https://user-images.githubusercontent.com/1745854/28636762-311cb2d8-720d-11e7-8ca7-7b87db615173.png)

![image](https://user-images.githubusercontent.com/1745854/28636776-3ddd9ca8-720d-11e7-9d6f-84258b0bc16e.png)
